### PR TITLE
Fix: Lengths of Tweets

### DIFF
--- a/twitter_python/part_3_analyzing_tweet_data/analyzing_twitter_data.py
+++ b/twitter_python/part_3_analyzing_tweet_data/analyzing_twitter_data.py
@@ -95,10 +95,10 @@ class TweetAnalyzer():
     Functionality for analyzing and categorizing content from tweets.
     """
     def tweets_to_data_frame(self, tweets):
-        df = pd.DataFrame(data=[tweet.text for tweet in tweets], columns=['Tweets'])
+        df = pd.DataFrame(data=[tweet.full_text for tweet in tweets], columns=['Tweets'])
 
         df['id'] = np.array([tweet.id for tweet in tweets])
-        df['len'] = np.array([len(tweet.text) for tweet in tweets])
+        df['len'] = np.array([len(tweet.full_text) for tweet in tweets])
         df['date'] = np.array([tweet.created_at for tweet in tweets])
         df['source'] = np.array([tweet.source for tweet in tweets])
         df['likes'] = np.array([tweet.favorite_count for tweet in tweets])
@@ -114,7 +114,7 @@ if __name__ == '__main__':
 
     api = twitter_client.get_twitter_client_api()
 
-    tweets = api.user_timeline(screen_name="realDonaldTrump", count=20)
+    tweets = api.user_timeline(screen_name="realDonaldTrump", count=20, tweet_mode="extended")
 
     #print(dir(tweets[0]))
     #print(tweets[0].retweet_count)


### PR DESCRIPTION
Returned tweets has truncated to 140 characters. 

As the character limit changed, tweetpy announced another parameter to API calls, `tweet_mode`, could be set to either `compat` or `extended`. Extended will return full_text instead of *truncated* text.

- [tweetpy docs](http://docs.tweepy.org/en/latest/extended_tweets.html)
- [video url](https://youtu.be/WX0MDddgpA4?t=1145)